### PR TITLE
Notification feature

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   def index
-    # TODO: extract loginc into a Search service
+    # TODO: extract logic into a Search service
     if _index_params[:user_id]
       @submitter = User[_index_params[:user_id]]
       scope = Movie.find(user_id: @submitter.id)

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -3,6 +3,7 @@ class VotesController < ApplicationController
     authorize! :vote, _movie
 
     _voter.vote(_type)
+    _notify_user
     redirect_to root_path, notice: 'Vote cast'
   end
 
@@ -29,5 +30,9 @@ class VotesController < ApplicationController
 
   def _movie
     @_movie ||= Movie[params[:movie_id]]
+  end
+
+  def _notify_user
+    UserMailer.notification_email(current_user, _movie, _type).deliver
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,12 @@
+class UserMailer < ActionMailer::Base
+  default from: 'notifications@movierama.com'
+
+  def notification_email(vote_caster, movie, like_or_hate)
+    @vote_caster  = vote_caster
+    @movie        = movie
+    @like_or_hate = like_or_hate
+    @user         = @movie.user
+
+    mail(to: @user.email, subject: 'Your movie has a new vote!')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < BaseModel
   include Ohm::Timestamps
 
   attribute :name
+  attribute :email
 
   # Unique identifier for this user, in the form "{provider}|{provider-id}"
   attribute :uid

--- a/app/services/user_registration.rb
+++ b/app/services/user_registration.rb
@@ -32,8 +32,9 @@ class UserRegistration
       @created = false
     else
       @user = User.create(
-        uid:        uid, 
+        uid:        uid,
         name:       @auth_hash['info']['name'],
+        email:      @auth_hash['info']['email'],
         created_at: Time.current.utc.to_i
       )
       @created = true

--- a/app/views/user_mailer/notification_email.text.haml
+++ b/app/views/user_mailer/notification_email.text.haml
@@ -1,0 +1,8 @@
+Dear #{@user.name},
+\
+Your movie #{@movie.title} was #{@like_or_hate}d by #{@vote_caster.name}.
+\
+\
+Regards,
+Movierama team
+

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,6 +4,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer unless Rails.env.production?
   provider :github,
     ENV.fetch('GITHUB_OAUTH_CLIENT_ID'),
-    ENV.fetch('GITHUB_OAUTH_SECRET')
+    ENV.fetch('GITHUB_OAUTH_SECRET'),
+    scope: 'user:email'
 end
 

--- a/db/users.yml
+++ b/db/users.yml
@@ -1,9 +1,13 @@
 - name: John McFoo
+  email: bit-bucket@test.smtp.org
   uid:  'null|johnmcfoo'
 - name: Alice Wallace
+  email: bit-bucket@test.smtp.org
   uid:  'null|alice'
 - name: Bob Ablleton
+  email: bit-bucket@test.smtp.org
   uid:  'null|bob'
 - name: Charlie O'Callaghan
+  email: bit-bucket@test.smtp.org
   uid:  'null|charlie'
 

--- a/spec/acceptance/voting_spec.rb
+++ b/spec/acceptance/voting_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe 'vote on movies', type: :feature do
   before do
     author = User.create(
       uid:  'null|12345',
-      name: 'Bob'
+      name: 'Bob',
+      email: 'bit-bucket@test.smtp.org'
     )
     Movie.create(
       title:        'Empire strikes back',
@@ -72,6 +73,19 @@ RSpec.describe 'vote on movies', type: :feature do
       expect {
         page.like('The Party')
       }.to raise_error(Capybara::ElementNotFound)
+    end
+
+    it 'generates an email when liked' do
+      page.like('Empire strikes back')
+      expect(ActionMailer::Base.deliveries).not_to be_empty
+    end
+
+    it 'does not generate an email when unliked' do
+      page.like('Empire strikes back')
+      deliveries_size = ActionMailer::Base.deliveries.size
+
+      page.unlike('Empire strikes back')
+      expect(ActionMailer::Base.deliveries.size).to eq(deliveries_size)
     end
   end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe UserMailer do
+
+  describe "#notification_email" do
+    let(:user) do
+      User.create(
+        uid: 'null|12345',
+        name: 'Critic',
+        email: 'bit-bucket@test.smtp.org'
+      )
+    end
+
+    let(:author) do
+      User.create(
+        uid: 'null|12346',
+        name: 'The real Bob',
+        email: 'bit-bucket@test.smtp.org'
+      )
+    end
+
+    let!(:email) { UserMailer.notification_email(user, movie, 'like').deliver}
+
+    let(:movie) do
+      Movie.create(
+        title:        'Empire strikes back',
+        description:  'Who\'s scruffy-looking?',
+        date:         '1980-05-21',
+        created_at:   Time.parse('2014-10-01 10:30 UTC').to_i,
+        user:         author,
+        liker_count:  50,
+        hater_count:  2
+      )
+    end
+
+    let(:email_content) do
+      "Your movie Empire strikes back was liked by Critic."
+    end
+
+    it "sends a message" do
+      expect(ActionMailer::Base.deliveries).not_to be_empty
+    end
+
+    it "has proper headers" do
+      expect(email.from).to eq(['notifications@movierama.com'])
+      expect(email.to).to eq([movie.user.email])
+      expect(email.subject).to eq('Your movie has a new vote!')
+      expect(email.body.to_s).to include(email_content)
+    end
+  end
+end


### PR DESCRIPTION
- Add functionality to email user when someone likes or hates their movie


Caveat:
This will send an email as soon as somebody likes/hates. However, good practices dictate that sending of email should be done outside the request pipeline. If I had time, I would include Resque and Resque Mailer to provide said functionality. I would also modify tests to check that a job has been queued.
