### PR TITLE
Notify author when vote cast

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem 'omniauth' # Authentication
 gem 'omniauth-github'
 gem 'cancan'   # Authorisation
 
+# Send email in background
+gem "sidekiq"
 
 # Debugger
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
+    connection_pool (2.2.0)
     diff-lcs (1.2.5)
     dotenv (1.0.2)
     dotenv-rails (1.0.2)
@@ -190,6 +191,8 @@ GEM
     redis-activesupport (4.0.0)
       activesupport (~> 4)
       redis-store (~> 1.1.0)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     redis-rack (1.5.0)
       rack (~> 1.5)
       redis-store (~> 1.1.0)
@@ -226,6 +229,12 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
+    sidekiq (3.4.1)
+      celluloid (~> 0.16.0)
+      connection_pool (>= 2.1.1)
+      json
+      redis (>= 3.0.6)
+      redis-namespace (>= 1.3.1)
     slop (3.6.0)
     sprockets (2.11.0)
       hike (~> 1.2)
@@ -286,9 +295,7 @@ DEPENDENCIES
   redis-rails
   rspec-rails
   sass-rails (~> 4.0.3)
+  sidekiq
   turbolinks
   uglifier (>= 1.3.0)
   unicorn
-
-BUNDLED WITH
-   1.10.6

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec unicorn -p $PORT -c config/unicorn.rb config.ru
+worker: bundle exec sidekiq

--- a/README.md
+++ b/README.md
@@ -72,3 +72,9 @@ If not, you'll need to get your own OAuth tokens from Github and edit
 So you know what to expect. This app's just a toy, remember?
 
 ![](https://dl.dropboxusercontent.com/spa/cbazgcyvth7jydp/-4eusn-o.png)
+
+### Sending emails
+
+To send emails you need to run sidekiq:
+
+`bundle exec sidekiq`

--- a/app/mailers/vote_mailer.rb
+++ b/app/mailers/vote_mailer.rb
@@ -1,0 +1,7 @@
+class VoteMailer < ActionMailer::Base
+  default from: "no-reply@movierama.dev"
+
+  def notify_author
+
+  end
+end

--- a/app/mailers/vote_mailer.rb
+++ b/app/mailers/vote_mailer.rb
@@ -1,7 +1,20 @@
 class VoteMailer < ActionMailer::Base
   default from: "no-reply@movierama.dev"
 
-  def notify_author
+  def notify_author(movie_id, voting_user_id, like_or_hate)
+    @movie = Movie[movie_id]
+    @author = @movie.user
+    @voting_user = User[voting_user_id]
+    @like_or_hate_verb = case like_or_hate
+                         when :like
+                          "liked"
+                         when :hate
+                          "hated"
+                         end
 
+    mail(
+      to: @author.email,
+      subject: "#{@voting_user.name} #{@like_or_hate_verb} #{@movie.title}",
+    )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < BaseModel
   include Ohm::Timestamps
 
   attribute :name
+  attribute :email
 
   # Unique identifier for this user, in the form "{provider}|{provider-id}"
   attribute :uid

--- a/app/services/voting_booth.rb
+++ b/app/services/voting_booth.rb
@@ -13,10 +13,11 @@ class VotingBooth
     end
     unvote # to guarantee consistency
     set.add(@user)
+    _notify_author(like_or_hate)
     _update_counts
     self
   end
-  
+
   def unvote
     @movie.likers.delete(@user)
     @movie.haters.delete(@user)
@@ -25,6 +26,10 @@ class VotingBooth
   end
 
   private
+
+  def _notify_author(like_or_hate)
+    VoteMailer.notify_author(@movie.id, @user.id, like_or_hate).deliver
+  end
 
   def _update_counts
     @movie.update(

--- a/app/services/voting_booth.rb
+++ b/app/services/voting_booth.rb
@@ -28,7 +28,7 @@ class VotingBooth
   private
 
   def _notify_author(like_or_hate)
-    VoteMailer.notify_author(@movie.id, @user.id, like_or_hate).deliver
+    VoteMailer.delay.notify_author(@movie.id, @user.id, like_or_hate)
   end
 
   def _update_counts

--- a/app/views/vote_mailer/notify_author.haml
+++ b/app/views/vote_mailer/notify_author.haml
@@ -1,0 +1,27 @@
+!!!
+%html
+  %head
+    %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
+  %body{style: "width: 100%; margin: 0 auto; background: #e5ffff"}
+    %table{style: "max-width: 600px; width: auto; margin: 0 auto; background: #fff; border: 1px solid #e5f2ff; display: block; padding: 40px 20px;", cellpadding: "5"}
+      %tbody{style: "font-family: 'Helvetica Neue', Ariel, Sans-serif;"}
+        %tr
+          %td
+            A little email from
+            %h2{style: "margin-top: 5px;"} MovieRama
+        %tr
+          %td
+            Hey #{@author.name},
+        %tr
+          %td
+            #{@voting_user.name}
+            #{@like_or_hate_verb}
+            #{@movie.title}.
+            %br/
+
+        %tr
+          %td
+            %small
+              Hope you have a great day!
+              %br/
+              The MovieRama Team

--- a/app/views/vote_mailer/notify_author.text.erb
+++ b/app/views/vote_mailer/notify_author.text.erb
@@ -1,0 +1,13 @@
+A little email from
+
+MovieRama
+=========
+
+
+Hey <%= @author.name %>,
+
+<%= @voting_user.name %> <%= @like_or_hate_verb %> <%= @movie.title %>.
+
+Hope you have a great day!
+
+The MovieRama team

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,3 +32,5 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end
+
+OmniAuth.config.full_host = "https://movierama.dev"

--- a/db/users.yml
+++ b/db/users.yml
@@ -1,9 +1,12 @@
 - name: John McFoo
   uid:  'null|johnmcfoo'
+  email: johnmcfoo@movierama.dev
 - name: Alice Wallace
   uid:  'null|alice'
+  email: alice@movierama.dev
 - name: Bob Ablleton
   uid:  'null|bob'
+  email: bob@movierama.dev
 - name: Charlie O'Callaghan
   uid:  'null|charlie'
-
+  email: charlie@movierama.dev

--- a/spec/acceptance/voting_spec.rb
+++ b/spec/acceptance/voting_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe 'vote on movies', type: :feature do
       date:         '1980-05-21',
       user:         author
     )
+
+    ActionMailer::Base.deliveries = []
   end
 
   context 'when logged out' do
@@ -39,11 +41,17 @@ RSpec.describe 'vote on movies', type: :feature do
     it 'can like' do
       page.like('Empire strikes back')
       expect(page).to have_vote_message
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.first.subject).to eq('John McFoo liked Empire strikes back')
+      expect(ActionMailer::Base.deliveries.first.to).to include('bob@movierama.dev')
     end
 
     it 'can hate' do
       page.hate('Empire strikes back')
       expect(page).to have_vote_message
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.first.subject).to eq('John McFoo hated Empire strikes back')
+      expect(ActionMailer::Base.deliveries.first.to).to include('bob@movierama.dev')
     end
 
     it 'can unlike' do
@@ -77,6 +85,3 @@ RSpec.describe 'vote on movies', type: :feature do
   end
 
 end
-
-
-

--- a/spec/acceptance/voting_spec.rb
+++ b/spec/acceptance/voting_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'vote on movies', type: :feature do
     it 'can like' do
       page.like('Empire strikes back')
       expect(page).to have_vote_message
-      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.length).to eq(1)
       expect(ActionMailer::Base.deliveries.first.subject).to eq('John McFoo liked Empire strikes back')
       expect(ActionMailer::Base.deliveries.first.to).to include('bob@movierama.dev')
     end
@@ -49,7 +49,7 @@ RSpec.describe 'vote on movies', type: :feature do
     it 'can hate' do
       page.hate('Empire strikes back')
       expect(page).to have_vote_message
-      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.length).to eq(1)
       expect(ActionMailer::Base.deliveries.first.subject).to eq('John McFoo hated Empire strikes back')
       expect(ActionMailer::Base.deliveries.first.to).to include('bob@movierama.dev')
     end

--- a/spec/acceptance/voting_spec.rb
+++ b/spec/acceptance/voting_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe 'vote on movies', type: :feature do
   before do
     author = User.create(
       uid:  'null|12345',
-      name: 'Bob'
+      name: 'Bob',
+      email: 'bob@movierama.dev'
     )
     Movie.create(
       title:        'Empire strikes back',

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,9 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require 'sidekiq/testing'
+Sidekiq::Testing.inline!
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/support/with_user.rb
+++ b/spec/support/with_user.rb
@@ -8,7 +8,8 @@ module RspecSupportWithUser
         :github,
         uid: '12345',
         info: {
-          name: 'John McFoo'
+          name: 'John McFoo',
+          email: 'john@movierama.dev'
         }
       )
     end


### PR DESCRIPTION
This PR allows MovieRama to send the Author of a review when another User likes or hates that film. It does this in the background using `sidekiq`'s `delay` method. It modifies the voting spec to assert that the email is sent with the correct information.

The first commit also contains a fix for redirecting to an auth callback in dev. Without the `full_host` being set the auth callback comes back to `http` which fails on a `redirect_uri_mismatch` error.