### PR TITLE
Email when vote recieved

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,17 @@ Login/signup use Omniauth with Github as a provider. If you're using Pow and the
 If not, you'll need to get your own OAuth tokens from Github and edit
 `.env` appropriately.
 
+#### Email in development
 
+Actionmailer is configured for [https://mailcatcher.me/](https://mailcatcher.me/)
+
+Run with with
+```
+gem install 'mailcatcher'
+mailcatcher
+```
+
+Then visit [http://localhost:1080](http://localhost:1080) to view emails.
 
 ### Screenshot
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,13 +3,18 @@ class UsersController < ApplicationController
   def edit
     authorize! :edit, User
     _set_user
+    @validator = NullValidator.instance
   end
 
   def update
     authorize! :update, User
     _set_user
 
-    if @current_user.update(_update_params)
+    @current_user.update_attributes(_update_params)
+    @validator = UserValidator.new(@current_user)
+
+    if @validator.valid?
+      @current_user.save
       flash[:notice] = "Preferences updated"
       redirect_to edit_user_url
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
 
     if @validator.valid?
       @current_user.save
-      flash[:notice] = "Preferences updated"
+      flash[:notice] = "Profile updated"
       redirect_to edit_user_url
     else
       flash[:error] = "Errors were detected"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,34 @@
+class UsersController < ApplicationController
+
+  def edit
+    authorize! :edit, User
+
+    @current_user = current_user
+    @validator = NullValidator.instance
+  end
+
+  def update
+    authorize! :update, User
+
+    @current_user = current_user
+    @validator = NullValidator.instance
+
+    @current_user.update_attributes(_update_params)
+
+    if @validator.valid?
+      @current_user.save
+      flash[:notice] = "Preferences updated"
+      redirect_to edit_user_url
+    else
+      flash[:error] = "Errors were detected"
+      render 'edit'
+    end
+  end
+
+  private
+
+  def _update_params
+    params.permit(:email)
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,21 +2,14 @@ class UsersController < ApplicationController
 
   def edit
     authorize! :edit, User
-
-    @current_user = current_user
-    @validator = NullValidator.instance
+    _set_user
   end
 
   def update
     authorize! :update, User
+    _set_user
 
-    @current_user = current_user
-    @validator = NullValidator.instance
-
-    @current_user.update_attributes(_update_params)
-
-    if @validator.valid?
-      @current_user.save
+    if @current_user.update(_update_params)
       flash[:notice] = "Preferences updated"
       redirect_to edit_user_url
     else
@@ -26,6 +19,10 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def _set_user
+    @current_user = current_user
+  end
 
   def _update_params
     params.permit(:email)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,4 @@
+class ApplicationMailer < ActionMailer::Base
+  default from: 'no-reply@movierama.com'
+
+end

--- a/app/mailers/vote_notification_mailer.rb
+++ b/app/mailers/vote_notification_mailer.rb
@@ -3,9 +3,8 @@ class VoteNotificationMailer < ActionMailer::Base
 
   def notification_email(movie)
     @movie = movie
-    @user = @movie.user
+    @author = @movie.user
 
-    @url  = 'http://example.com/login'
-    mail(to: 'no_one@email.com', subject: "#{@movie.title} has a new vote!")
+    mail(to: @author.email, subject: "#{@movie.title} has a new vote!")
   end
 end

--- a/app/mailers/vote_notification_mailer.rb
+++ b/app/mailers/vote_notification_mailer.rb
@@ -1,0 +1,11 @@
+class VoteNotificationMailer < ActionMailer::Base
+  default from: "from@example.com"
+
+  def notification_email(movie)
+    @movie = movie
+    @user = @movie.user
+
+    @url  = 'http://example.com/login'
+    mail(to: 'no_one@email.com', subject: "#{@movie.title} has a new vote!")
+  end
+end

--- a/app/mailers/vote_notification_mailer.rb
+++ b/app/mailers/vote_notification_mailer.rb
@@ -1,5 +1,4 @@
-class VoteNotificationMailer < ActionMailer::Base
-  default from: "from@example.com"
+class VoteNotificationMailer < ApplicationMailer
 
   def notification_email(movie)
     @movie = movie

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,5 +9,9 @@ class Ability
     end
 
     can :create, Movie
+
+    can :edit, User
+    can :update, User
+
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < BaseModel
   include Ohm::Timestamps
 
   attribute :name
+  attribute :email
 
   # Unique identifier for this user, in the form "{provider}|{provider-id}"
   attribute :uid

--- a/app/services/author_notifier.rb
+++ b/app/services/author_notifier.rb
@@ -1,0 +1,19 @@
+class AuthorNotifier
+
+  def initialize(movie)
+    @movie = movie
+    @author = movie.user
+
+    _notify_author if _notify_me_enabled
+  end
+
+  private
+
+  def _notify_me_enabled
+    @author.email.present?
+  end
+
+  def _notify_author
+    VoteNotificationMailer.notification_email(@movie).deliver
+  end
+end

--- a/app/services/user_validator.rb
+++ b/app/services/user_validator.rb
@@ -1,0 +1,25 @@
+class UserValidator
+  def initialize(user)
+    @user = user
+    @errors = nil
+  end
+
+  def valid?
+    errors.empty?
+  end
+
+  def errors
+    return @errors if @errors
+    @errors = {}
+
+    if @user.email.blank? || @user.email.exclude?('@')
+      @errors[:email] = true
+    end
+
+    @errors
+  end
+
+  def class_for(field)
+    errors[field] ? "has-error" : ""
+  end
+end

--- a/app/services/user_validator.rb
+++ b/app/services/user_validator.rb
@@ -12,7 +12,7 @@ class UserValidator
     return @errors if @errors
     @errors = {}
 
-    if @user.email.blank? || @user.email.exclude?('@')
+    unless _blank_email? || _valid_email?
       @errors[:email] = true
     end
 
@@ -21,5 +21,15 @@ class UserValidator
 
   def class_for(field)
     errors[field] ? "has-error" : ""
+  end
+
+  private
+
+  def _blank_email?
+    @user.email.blank?
+  end
+
+  def _valid_email?
+    @user.email.include?('@')
   end
 end

--- a/app/services/voting_booth.rb
+++ b/app/services/voting_booth.rb
@@ -14,7 +14,7 @@ class VotingBooth
     unvote # to guarantee consistency
     set.add(@user)
     _update_counts
-    _notify_owner
+    _notify_author
     self
   end
 
@@ -33,7 +33,7 @@ class VotingBooth
       hater_count: @movie.haters.size)
   end
 
-  def _notify_owner
-    VoteNotificationMailer.notification_email(@movie).deliver
+  def _notify_author
+    AuthorNotifier.new(@movie)
   end
 end

--- a/app/services/voting_booth.rb
+++ b/app/services/voting_booth.rb
@@ -14,9 +14,10 @@ class VotingBooth
     unvote # to guarantee consistency
     set.add(@user)
     _update_counts
+    _notify_owner
     self
   end
-  
+
   def unvote
     @movie.likers.delete(@user)
     @movie.haters.delete(@user)
@@ -30,5 +31,9 @@ class VotingBooth
     @movie.update(
       liker_count: @movie.likers.size,
       hater_count: @movie.haters.size)
+  end
+
+  def _notify_owner
+    VoteNotificationMailer.notification_email(@movie).deliver
   end
 end

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -19,6 +19,8 @@
           %p.navbar-text.navbar-right
             Welcome back,
             %span#username= current_user.name
+            = link_to edit_user_path do
+              Profile
             = link_to session_path, method: :delete do
               Log out
         - else

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -1,0 +1,16 @@
+
+.container
+  .row
+    .col-md-12
+      .page-header
+        %h2 Edit your preferences
+  .row
+    .col-md-9
+      Enter your email to recieve notifications
+      = form_tag user_path, { method: :put,  class: 'form', role: 'form' } do |f|
+        .form-group{ class: @validator.class_for(:email) }
+          %label{ for:  'email' } Email
+          %input.form-control{ name: 'email', value: @current_user.email  }
+
+        .form-group
+          = submit_tag 'Update preferences', class: 'btn btn-primary'

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -3,7 +3,7 @@
   .row
     .col-md-12
       .page-header
-        %h2 Edit your preferences
+        %h2 Edit your Profile
   .row
     .col-md-9
       Enter your email to recieve notifications
@@ -13,4 +13,4 @@
           %input.form-control{ name: 'email', value: @current_user.email  }
 
         .form-group
-          = submit_tag 'Update preferences', class: 'btn btn-primary'
+          = submit_tag 'Update Profile', class: 'btn btn-primary'

--- a/app/views/vote_notification_mailer/notification_email.text.erb
+++ b/app/views/vote_notification_mailer/notification_email.text.erb
@@ -1,0 +1,1 @@
+<%= @movie.title %> has a new vote!

--- a/app/views/vote_notification_mailer/notification_email.text.erb
+++ b/app/views/vote_notification_mailer/notification_email.text.erb
@@ -1,1 +1,1 @@
-<%= @movie.title %> has a new vote!
+<%= @movie.title %> has a new vote on Movierama.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,6 +16,10 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  # Use mailcatcher defaults
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  
+
   resource :session, only: %i(create destroy)
   get '/auth/:provider/callback', to: 'sessions#create'
 
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   resources :users, only: %i() do
     resources :movies, only: %(index), controller: 'movies'
   end
+
+  resource :user, only: %i(edit update)
 
   root 'movies#index'
 end

--- a/spec/acceptance/email_vote_notification_spec.rb
+++ b/spec/acceptance/email_vote_notification_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 require 'capybara/rails'
 require 'support/pages/movie_list'
-require 'support/pages/movie_new'
 require 'support/with_user'
 
 RSpec.describe 'email vote notification to user', type: :feature do

--- a/spec/acceptance/email_vote_notification_spec.rb
+++ b/spec/acceptance/email_vote_notification_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe 'email vote notification to user', type: :feature do
   before do
     author = User.create(
       uid:  'null|12345',
-      name: 'Bob'
+      name: 'Bob',
+      email: 'bob@starwars.com'
     )
     Movie.create(
       title:        'Empire strikes back',
@@ -31,6 +32,13 @@ RSpec.describe 'email vote notification to user', type: :feature do
         expect { page.like('Empire strikes back') }
         .to change { ActionMailer::Base.deliveries.count }.by(1)
       end
+
+      it 'sends an email to the author' do
+        page.hate('Empire strikes back')
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.to).to eq ['bob@starwars.com']
+      end
+
     end
 
     context 'when hated' do
@@ -38,8 +46,13 @@ RSpec.describe 'email vote notification to user', type: :feature do
         expect { page.hate('Empire strikes back') }
         .to change { ActionMailer::Base.deliveries.count }.by(1)
       end
-    end
 
+      it 'sends an email to the author' do
+        page.hate('Empire strikes back')
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.to).to eq ['bob@starwars.com']
+      end
+    end
   end
 end
 

--- a/spec/acceptance/email_vote_notification_spec.rb
+++ b/spec/acceptance/email_vote_notification_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+require 'capybara/rails'
+require 'support/pages/movie_list'
+require 'support/pages/movie_new'
+require 'support/with_user'
+
+RSpec.describe 'email vote notification to user', type: :feature do
+
+  let(:page) { Pages::MovieList.new }
+
+  before do
+    author = User.create(
+      uid:  'null|12345',
+      name: 'Bob'
+    )
+    Movie.create(
+      title:        'Empire strikes back',
+      description:  'Who\'s scruffy-looking?',
+      date:         '1980-05-21',
+      user:         author
+    )
+  end
+
+  context 'when logged in' do
+    with_logged_in_user
+
+    before { page.open }
+
+    context 'when liked' do
+      it 'sends an email' do
+        expect { page.like('Empire strikes back') }
+        .to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+    end
+
+    context 'when hated' do
+      it 'sends an email' do
+        expect { page.hate('Empire strikes back') }
+        .to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+    end
+
+  end
+end
+
+
+

--- a/spec/acceptance/users_spec.rb
+++ b/spec/acceptance/users_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+require 'capybara/rails'
+require 'support/pages/user_edit'
+require 'support/with_user'
+
+RSpec.describe "User ", type: :feature do
+
+  let(:page) { Pages::UserEdit.new }
+
+  with_logged_in_user
+
+  describe "edit user profile" do
+    describe 'email' do
+      context 'with valid email' do
+        it 'updates email' do
+          page.open
+          page.submit(email: 'tk-421@deathstar.emp')
+          expect(page).to have_user_updated_message
+        end
+      end
+
+      context 'with blank email' do
+        it 'updates email' do
+          page.open
+          page.submit(email: '')
+          expect(page).to have_user_updated_message
+        end
+      end
+
+      context 'with invalid email' do
+        it 'displays error' do
+          page.open
+          page.submit(email: 'not an email address')
+          expect(page).to have_error_message
+        end
+      end
+    end
+  end
+end

--- a/spec/support/pages/user_edit.rb
+++ b/spec/support/pages/user_edit.rb
@@ -1,0 +1,26 @@
+require 'capybara/rspec'
+
+module Pages
+  class UserEdit
+    include Capybara::DSL
+
+    def open
+      visit('/user/edit')
+      self
+    end
+
+    def submit(email:)
+      fill_in 'email', with: email
+      click_on 'Update Profile'
+      self
+    end
+
+    def has_user_updated_message?
+      page.has_content?('Profile updated')
+    end
+
+    def has_error_message?
+      page.has_content?('Errors were detected')
+    end
+  end
+end


### PR DESCRIPTION
> Please add a ‘notify me’ feature that sends users an email as soon as somebody likes/hates one of the movies they've submitted, and prepare a corresponding pull request.

Email address can be configured by visiting /user/edit
Having a valid email address will enable notifications.

AuthorNotifier service can be changed if different mechanism is preferred for enabling/disabling notifications.

Feature tests included for testing emails, and configuring email address.