### PR TITLE
[NOTIFY] Send notification emails on reactions

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,5 @@ GITHUB_OAUTH_CLIENT_ID:	d4aad0f8c68fababee8a
 GITHUB_OAUTH_SECRET:	e7749d16251801499d9b7d7f376b7d8dbfe189b4
 
 NEW_RELIC_KEY:		none
+
+SITEURL: https://movierame.dev

--- a/.env
+++ b/.env
@@ -10,4 +10,3 @@ GITHUB_OAUTH_SECRET:	e7749d16251801499d9b7d7f376b7d8dbfe189b4
 
 NEW_RELIC_KEY:		none
 
-SITEURL: https://movierame.dev

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# coding: utf-8
 source 'https://rubygems.org'
 
 ruby '2.2.2'
@@ -58,10 +59,14 @@ gem 'pry'
 gem 'pry-nav'
 gem 'pry-doc'
 
+group :development, :test do
+  gem 'rspec-rails'    # Test framework with Rail extensions
+  gem 'mailcatcher', require: false
+end
 
 group :test do
   gem 'guard-rspec'    # Continuous testing
-  gem 'rspec-rails'    # Test framework with Rail extensions
   gem 'poltergeist'    # Driver for PhantomJS headless browser
   gem 'capybara'       # DSL for browser control
+  gem 'launchy'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (5.0.1.20140414130214)
     bootstrap-sass (3.2.0.2)
       sass (~> 3.2)
@@ -49,6 +50,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
+    daemons (1.2.4)
     diff-lcs (1.2.5)
     dotenv (1.0.2)
     dotenv-rails (1.0.2)
@@ -59,6 +61,7 @@ GEM
       activesupport (>= 3.0)
       request_store (~> 1.0)
     erubis (2.7.0)
+    eventmachine (1.0.9.1)
     execjs (2.2.2)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
@@ -94,6 +97,8 @@ GEM
     json (1.8.1)
     jwt (1.0.0)
     kgio (2.9.2)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (2.7.11)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -101,6 +106,14 @@ GEM
     lumberjack (1.0.9)
     mail (2.6.1)
       mime-types (>= 1.16, < 3)
+    mailcatcher (0.6.5)
+      eventmachine (= 1.0.9.1)
+      mail (~> 2.3)
+      rack (~> 1.5)
+      sinatra (~> 1.2)
+      skinny (~> 0.2.3)
+      sqlite3 (~> 1.3)
+      thin (~> 1.5.0)
     method_source (0.8.2)
     mime-types (2.4.2)
     mini_portile (0.6.0)
@@ -151,6 +164,8 @@ GEM
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
     rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
     rack-ssl (1.4.1)
       rack
     rack-test (0.6.2)
@@ -226,6 +241,13 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    skinny (0.2.4)
+      eventmachine (~> 1.0.0)
+      thin (>= 1.5, < 1.7)
     slop (3.6.0)
     sprockets (2.11.0)
       hike (~> 1.2)
@@ -236,6 +258,11 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sqlite3 (1.3.11)
+    thin (1.5.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -271,6 +298,8 @@ DEPENDENCIES
   guard-rspec
   haml-rails
   jquery-rails
+  launchy
+  mailcatcher
   newrelic_rpm
   ohm
   ohm-contrib

--- a/README.md
+++ b/README.md
@@ -66,9 +66,18 @@ If not, you'll need to get your own OAuth tokens from Github and edit
 `.env` appropriately.
 
 
-
 ### Screenshot
 
 So you know what to expect. This app's just a toy, remember?
 
 ![](https://dl.dropboxusercontent.com/spa/cbazgcyvth7jydp/-4eusn-o.png)
+
+### Emails
+
+Emails can be [pre-viewed](https://movierama.dev/rails/mailers) and are available
+in html as well as text.
+
+In development emails are sent via mailcatcher, to make this work mailcatcher
+needs to be running `mailcatcher`. View the mails at
+[the interface](http://127.0.0.1:1080) in a browser.
+

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -2,7 +2,9 @@ class VotesController < ApplicationController
   def create
     authorize! :vote, _movie
 
-    _voter.vote(_type)
+    _voter.vote(_type) do
+      _notification.trigger
+    end
     redirect_to root_path, notice: 'Vote cast'
   end
 
@@ -17,6 +19,10 @@ class VotesController < ApplicationController
 
   def _voter
     VotingBooth.new(current_user, _movie)
+  end
+
+  def _notification
+    NotificationCenter.new(current_user, _movie)
   end
 
   def _type

--- a/app/mailers/vote_mailer.rb
+++ b/app/mailers/vote_mailer.rb
@@ -1,0 +1,13 @@
+class VoteMailer < ActionMailer::Base
+  default from: "do-not-repley@#{Rails.application.config.site_url}"
+
+  # TODO setup Resque for delayed jobs
+
+  def notification(movie, voter)
+    @movie = movie
+    @url = Rails.application.config.site_url
+    @voter = voter
+
+    mail(to: movie.user.formatted_email, subject: "New reaction on #{movie.title}")
+  end
+end

--- a/app/mailers/vote_mailer.rb
+++ b/app/mailers/vote_mailer.rb
@@ -1,13 +1,8 @@
 class VoteMailer < ActionMailer::Base
-  default from: "do-not-repley@#{Rails.application.config.site_url}"
+  default from: "do-not-reply@#{Rails.application.config.site_url}"
 
-  # TODO setup Resque for delayed jobs
-
-  def notification(movie, voter)
-    @movie = movie
-    @url = Rails.application.config.site_url
-    @voter = voter
-
-    mail(to: movie.user.formatted_email, subject: "New reaction on #{movie.title}")
+  def notification(data)
+    @data = data
+    mail(data.to_h)
   end
 end

--- a/app/mailers/vote_mailer_preview.rb
+++ b/app/mailers/vote_mailer_preview.rb
@@ -1,6 +1,7 @@
 class VoteMailerPreview < ActionMailer::Preview
   def notification
-    VoteMailer.notification(default_movie, default_user)
+    data = NotificationData.new(default_user, default_movie)
+    VoteMailer.notification(data)
   end
 
   private

--- a/app/mailers/vote_mailer_preview.rb
+++ b/app/mailers/vote_mailer_preview.rb
@@ -1,0 +1,19 @@
+class VoteMailerPreview < ActionMailer::Preview
+  def notification
+    VoteMailer.notification(default_movie, default_user)
+  end
+
+  private
+  def default_movie
+    Movie.all.first || Movie.create(title: "Clerks",
+                                    description: "A good movie",
+                                    date: "1994-10-19",
+                                    user: default_user)
+  end
+
+  def default_user
+    User.all.first || User.create(uid: "null|12345",
+                                  name: "Bob",
+                                  email: "bob@example.com")
+  end
+end

--- a/app/models/notification_data.rb
+++ b/app/models/notification_data.rb
@@ -1,0 +1,44 @@
+class NotificationData
+  attr_reader :voter, :movie
+
+  def initialize(voter, movie)
+    @voter = voter
+    @movie = movie
+  end
+
+  def url
+    Rails.application.config.site_url
+  end
+
+  def voter_name
+    if @voter.name.blank?
+      "Someone"
+    else
+      @voter.name
+    end
+  end
+
+  def link_name
+    "Movierama"
+  end
+
+  def subject
+    "New reaction on #{movie.title}"
+  end
+
+  def to
+    if target.name.nil?
+      target.email
+    else
+      "#{target.name} <#{target.email}>"
+    end
+  end
+
+  def target
+    movie.user
+  end
+
+  def to_h
+    { to: to, subject: subject }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,11 +16,7 @@ class User < BaseModel
   # Submitted movies
   collection :movies, :Movie
 
-  def formatted_email
-    "#{name} <#{email}>"
-  end
-
-  def subscribed?
+  def email?
     email.present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < BaseModel
   include Ohm::Timestamps
 
   attribute :name
+  attribute :email
 
   # Unique identifier for this user, in the form "{provider}|{provider-id}"
   attribute :uid
@@ -14,4 +15,12 @@ class User < BaseModel
 
   # Submitted movies
   collection :movies, :Movie
+
+  def formatted_email
+    "#{name} <#{email}>"
+  end
+
+  def subscribed?
+    email.present?
+  end
 end

--- a/app/services/notification_center.rb
+++ b/app/services/notification_center.rb
@@ -1,0 +1,18 @@
+class NotificationCenter
+
+  def initialize(voter, movie)
+    @voter = voter
+    @movie = movie
+  end
+
+  def trigger
+    data = NotificationData.new(@voter, @movie)
+    VoteMailer.notification(data).deliver if subscribed?
+  end
+
+  private
+
+  def subscribed?
+    @movie.user.email?
+  end
+end

--- a/app/services/user_registration.rb
+++ b/app/services/user_registration.rb
@@ -34,6 +34,7 @@ class UserRegistration
       @user = User.create(
         uid:        uid, 
         name:       @auth_hash['info']['name'],
+        email:      @auth_hash['info']['email'],
         created_at: Time.current.utc.to_i
       )
       @created = true

--- a/app/services/voting_booth.rb
+++ b/app/services/voting_booth.rb
@@ -14,7 +14,7 @@ class VotingBooth
     unvote # to guarantee consistency
     set.add(@user)
     _update_counts
-    notify!
+    yield if block_given?
     self
   end
   
@@ -26,11 +26,6 @@ class VotingBooth
   end
 
   private
-
-  def notify!
-    VoteMailer.notification(@movie, @user).deliver if @movie.user.subscribed?
-  end
-
   def _update_counts
     @movie.update(
       liker_count: @movie.likers.size,

--- a/app/services/voting_booth.rb
+++ b/app/services/voting_booth.rb
@@ -14,6 +14,7 @@ class VotingBooth
     unvote # to guarantee consistency
     set.add(@user)
     _update_counts
+    notify!
     self
   end
   
@@ -25,6 +26,10 @@ class VotingBooth
   end
 
   private
+
+  def notify!
+    VoteMailer.notification(@movie, @user).deliver if @movie.user.subscribed?
+  end
 
   def _update_counts
     @movie.update(

--- a/app/views/vote_mailer/notification.haml
+++ b/app/views/vote_mailer/notification.haml
@@ -1,0 +1,18 @@
+!!!
+%html
+  %head
+    %meta{ 'http-equiv' => 'content-type', content: "text/html;charset=UTF-8" }/
+
+  %body
+    %h1
+      = @voter.name
+      reacted to
+      = @movie.title
+    %p
+      Visit
+      = link_to "Movierama", @url
+      to see what is going on!
+
+    %p
+      Your Movierama Team
+

--- a/app/views/vote_mailer/notification.haml
+++ b/app/views/vote_mailer/notification.haml
@@ -5,12 +5,12 @@
 
   %body
     %h1
-      = @voter.name
+      = @data.voter_name
       reacted to
-      = @movie.title
+      = @data.movie.title
     %p
       Visit
-      = link_to "Movierama", @url
+      = link_to @data.link_name, @data.url
       to see what is going on!
 
     %p

--- a/app/views/vote_mailer/notification.text.erb
+++ b/app/views/vote_mailer/notification.text.erb
@@ -1,0 +1,5 @@
+<%= @voter.name %> reacted to <%= @movie.title %>
+
+Visit <%= @url %> to see what is going on!
+
+Your Movierame Team

--- a/app/views/vote_mailer/notification.text.erb
+++ b/app/views/vote_mailer/notification.text.erb
@@ -1,5 +1,5 @@
-<%= @voter.name %> reacted to <%= @movie.title %>
+<%= @data.voter_name %> reacted to <%= @data.movie.title %>
 
-Visit <%= @url %> to see what is going on!
+Visit <%= @data.url %> to see what is going on!
 
 Your Movierame Team

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -6,6 +6,8 @@ Rails.application.configure do
 
   config.middleware.use ActionDispatch::Flash
   config.middleware.insert 0, Rack::SSL
+
+  config.site_url = ENV.fetch("SITEURL", "https://movierama.dev")
 end
 
 # Initialize the Rails application.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,4 +31,12 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Mailer previews
+  config.action_mailer.preview_path = "#{Rails.root}/app/mailers"
+
+  # Email goes to mailcatcher in development
+  config.action_mailer.default_url_options = { :host => 'movierama.dev' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => 'movierama.dev', :port => 1025 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,4 +72,18 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.sendgrid.net',
+    port: '587',
+    authentication: :plain,
+    user_name: ENV.fetch('SENDGRID_USERNAME'),
+    password: ENV.fetch('SENDGRID_PASSWORD'),
+    domain: 'movierama.com',
+    enable_starttls_auto: true
+  }
+  config.action_mailer.default_url_options = { host: 'movierama.com' }
+
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,9 +1,11 @@
 require 'omniauth'
 
-# OmniAuth.config.full_host = "https://movierama.dev"
+
+OmniAuth.config.full_host = Rails.application.config.site_url unless Rails.env.test?
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer unless Rails.env.production?
+
   provider :github,
     ENV.fetch('GITHUB_OAUTH_CLIENT_ID'),
     ENV.fetch('GITHUB_OAUTH_SECRET'),

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,9 +1,11 @@
 require 'omniauth'
 
+# OmniAuth.config.full_host = "https://movierama.dev"
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer unless Rails.env.production?
   provider :github,
     ENV.fetch('GITHUB_OAUTH_CLIENT_ID'),
-    ENV.fetch('GITHUB_OAUTH_SECRET')
+    ENV.fetch('GITHUB_OAUTH_SECRET'),
+    scope: "user:email"
 end
-

--- a/db/users.yml
+++ b/db/users.yml
@@ -1,9 +1,16 @@
 - name: John McFoo
   uid:  'null|johnmcfoo'
+  email: 'johnmcfoo@example.com'
 - name: Alice Wallace
   uid:  'null|alice'
+  email: 'alice@example.com'
 - name: Bob Ablleton
   uid:  'null|bob'
-- name: Charlie O'Callaghan
+  email: 'bob@example.com'
+- name: "Charlie O'Callaghan"
   uid:  'null|charlie'
+  email: 'charlie@example.com'
+- name: Secret Secretson
+  uid: 'null|secret'
+  
 

--- a/spec/acceptance/voting_spec.rb
+++ b/spec/acceptance/voting_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe 'vote on movies', type: :feature do
   before do
     author = User.create(
       uid:  'null|12345',
-      name: 'Bob'
+      name: 'Bob',
+      email: 'bob@example.com'
     )
     Movie.create(
       title:        'Empire strikes back',
@@ -72,6 +73,16 @@ RSpec.describe 'vote on movies', type: :feature do
       expect {
         page.like('The Party')
       }.to raise_error(Capybara::ElementNotFound)
+    end
+
+    it 'sends an email after like' do
+      page.like('Empire strikes back')
+      expect(ActionMailer::Base.deliveries).to_not be_empty
+    end
+
+    it 'sends an email after hate' do
+      page.like('Empire strikes back')
+      expect(ActionMailer::Base.deliveries).to_not be_empty
     end
   end
 

--- a/spec/mailers/vote_mailer_spec.rb
+++ b/spec/mailers/vote_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe VoteMailer, :type => :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/vote_mailer_spec.rb
+++ b/spec/mailers/vote_mailer_spec.rb
@@ -1,5 +1,0 @@
-require "rails_helper"
-
-RSpec.describe VoteMailer, :type => :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/notification_data_spec.rb
+++ b/spec/models/notification_data_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe NotificationData, type: :model do
+
+  let(:user) { User.create(uid: 'null|12345', name: 'Bob', email: 'bob@example.com') }
+
+  let(:movie) do
+    Movie.create(title: 'Empire strikes back',
+                 description: 'Who\'s scruffy-looking?',
+                 date: '1980-05-21',
+                 user: user)
+  end
+
+  describe "voter name" do
+    it "uses the user name if present" do
+      expect(NotificationData.new(user, movie).voter_name).to eq "Bob"
+    end
+
+    it "defaults to a default if no name is present" do
+      user.name = nil
+      expect(NotificationData.new(user, movie).voter_name).to eq "Someone"
+    end
+  end
+
+
+  describe "email formatting" do
+    it "includes the name for users with name set" do
+      expect(NotificationData.new(user, movie).to).to eq "Bob <bob@example.com>"
+    end
+
+    it "returns email for users with no set name" do
+      movie.user.name = nil
+      expect(NotificationData.new(user, movie).to).to eq "bob@example.com"
+    end
+  end
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,23 +1,8 @@
 require "rails_helper"
 
-RSpec.describe User, :type => :model do
-
-  subject do
-    User.create name: "Bob", uid: "unique|id", email: "bob@example.com"
-  end
-
-  describe "notifications" do
-    it "creates email ready for sending" do
-      expect(subject.formatted_email).to eq "Bob <bob@example.com>"
-    end
-
-    it "receives notification" do
-      expect(subject.subscribed?).to be true
-    end
-
-    it "does not receive notifications without email" do
-      subject.email = ""
-      expect(subject.subscribed?).to be false
-    end
+RSpec.describe User, :type => :model, focus: true do
+  it "determines email presence" do
+    expect(User.new(email: "bob@example.com").email?).to be true
+    expect(User.new.email?).to be false
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe User, :type => :model do
+
+  subject do
+    User.create name: "Bob", uid: "unique|id", email: "bob@example.com"
+  end
+
+  describe "notifications" do
+    it "creates email ready for sending" do
+      expect(subject.formatted_email).to eq "Bob <bob@example.com>"
+    end
+
+    it "receives notification" do
+      expect(subject.subscribed?).to be true
+    end
+
+    it "does not receive notifications without email" do
+      subject.email = ""
+      expect(subject.subscribed?).to be false
+    end
+  end
+end

--- a/spec/services/notification_center_spec.rb
+++ b/spec/services/notification_center_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe NotificationCenter do
+  describe "sending" do
+
+    before { ActionMailer::Base.deliveries = [] }
+
+    let(:user) do
+      User.create(uid: 'null|12345',
+                  name: 'Bob',
+                  email: 'bob@example.com')
+    end
+
+    let(:movie) do
+      Movie.create(title: 'Empire strikes back',
+                   description: 'Who\'s scruffy-looking?',
+                   date: '1980-05-21',
+                   user: user)
+    end
+
+
+    it "does send to user with email" do
+      NotificationCenter.new(user, movie).trigger
+      expect(ActionMailer::Base.deliveries).to_not be_empty
+    end
+
+    it "does not sent to users without email" do
+      movie.user.email = nil
+      NotificationCenter.new(user, movie).trigger
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+
+  end
+end

--- a/spec/services/user_registration_spec.rb
+++ b/spec/services/user_registration_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe UserRegistration do
+
+  let(:auth_hash) do
+    {
+      "provider" => "github",
+      "uid" => "12345",
+      "info"=> { "nickname" => "Bob", "email" => "bob@example.com", "name"=>"Bob"}
+    }
+  end
+
+  subject do
+    UserRegistration.new(auth_hash)
+  end
+
+  it "creates a user with auth_hash attributes" do
+    expect(subject.user.email).to eq auth_hash["info"]["email"]
+    expect(subject.user.name).to eq auth_hash["info"]["name"]
+  end
+
+  it "creates a uid for the user" do
+    expect(subject.user.uid).to eq "#{auth_hash['provider']}|#{auth_hash['uid']}"
+  end
+
+end

--- a/spec/services/voting_booth_spec.rb
+++ b/spec/services/voting_booth_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe VotingBooth do
+
+  subject do
+    user = User.create(uid: 'null|12345',
+                       name: 'Bob',
+                       email: 'bob@example.com')
+    movie = Movie.create(title: 'Empire strikes back',
+                         description: 'Who\'s scruffy-looking?',
+                         date: '1980-05-21',
+                         user: user)
+    VotingBooth.new(user, movie)
+  end
+
+  it "triggers hooks on vote" do
+    expect { |b| subject.vote(:like, &b) }.to yield_control
+  end
+end


### PR DESCRIPTION
When a user reacts to a movie send a notification email. For testing
emails can be viewed via normal rails mailer preview and wil be sent to
local mailcatcher for checking. For production use Sendgrid is
preconfigured and needs appropriately configured USERNAME and PASSWORD
provided via env variables, see production.rb for configuration.
# Improvements

add delayed sending to not impact site load speed, this could be done via Resque as we already have Redis present, or others. As this create a big overhead on monitoring the availability of the workers and the whole worker system in general this should only be added if needed due to load.
