### PR TITLE
[email] add email-sending on vote

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,13 @@ UNICORN_WORKERS:	4
 UNICORN_TIMEOUT:	300
 
 # These work for https://movierama.dev
-GITHUB_OAUTH_CLIENT_ID:	d4aad0f8c68fababee8a
-GITHUB_OAUTH_SECRET:	e7749d16251801499d9b7d7f376b7d8dbfe189b4
+GITHUB_OAUTH_CLIENT_ID:	40a4c6d60aec1fc2b040
+GITHUB_OAUTH_SECRET:	b893a436e72b15babc4982017a0616d7c1afb419
 
-NEW_RELIC_KEY:		none
+NEW_RELIC_KEY:		69485e46373fb8a7a439a0b0440fe2b1c2a0998f
+
+# mailgun
+api_key: 'key-c37046d1e571eb78c835613c272ee543'
+domain: 'sandbox3ceb4f2a8a3c4f189c9d38cec78a16ca.mailgun.org'
+username: 'postmaster@sandbox3ceb4f2a8a3c4f189c9d38cec78a16ca.mailgun.org'
+password: '24c80f55a887e54d9fd3d8d1b7524ca4'

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+.rbenv-gemsets

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'rack-ssl'
 # Use Redis as backing store
 gem 'ohm'
 gem 'ohm-contrib'
+gem 'ohm-validations'
 
 # ♥︎ thin models
 gem 'draper'
@@ -52,16 +53,21 @@ gem 'omniauth' # Authentication
 gem 'omniauth-github'
 gem 'cancan'   # Authorisation
 
+# Email sending
+gem 'mailgun-ruby', '~>1.0.2', require: 'mailgun'
 
 # Debugger
 gem 'pry'
 gem 'pry-nav'
 gem 'pry-doc'
 
+gem 'byebug'
 
 group :test do
   gem 'guard-rspec'    # Continuous testing
   gem 'rspec-rails'    # Test framework with Rail extensions
   gem 'poltergeist'    # Driver for PhantomJS headless browser
   gem 'capybara'       # DSL for browser control
+  gem 'rubocop'
+  gem 'rails_best_practices'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,9 +28,11 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
+    ast (2.3.0)
     bootstrap-sass (3.2.0.2)
       sass (~> 3.2)
     builder (3.2.2)
+    byebug (9.0.6)
     cancan (1.6.10)
     capybara (2.4.4)
       mime-types (>= 1.16)
@@ -41,6 +43,8 @@ GEM
     celluloid (0.16.0)
       timers (~> 4.0.0)
     cliver (0.3.2)
+    code_analyzer (0.4.7)
+      sexp_processor
     coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -50,6 +54,8 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     diff-lcs (1.2.5)
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (1.0.2)
     dotenv-rails (1.0.2)
       dotenv (= 1.0.2)
@@ -87,6 +93,8 @@ GEM
     hike (1.2.3)
     hiredis (0.5.2)
     hitimes (1.2.2)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (0.6.11)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
@@ -101,6 +109,9 @@ GEM
     lumberjack (1.0.9)
     mail (2.6.1)
       mime-types (>= 1.16, < 3)
+    mailgun-ruby (1.0.3)
+      json (~> 1.8)
+      rest-client (~> 1.6)
     method_source (0.8.2)
     mime-types (2.4.2)
     mini_portile (0.6.0)
@@ -109,6 +120,7 @@ GEM
     multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    netrc (0.11.0)
     newrelic_rpm (3.9.5.251)
     nido (0.0.1)
     nokogiri (1.6.3.1)
@@ -125,6 +137,9 @@ GEM
       redic
     ohm-contrib (2.0.0)
       ohm (~> 2.0.0)
+    ohm-validations (1.0.0)
+      ohm (~> 2.0)
+      scrivener (~> 1.0)
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
@@ -136,11 +151,14 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    parser (2.4.0.0)
+      ast (~> 2.2)
     poltergeist (1.5.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
+    powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -168,6 +186,14 @@ GEM
     rails_12factor (0.0.2)
       rails_serve_static_assets
       rails_stdout_logging
+    rails_best_practices (1.17.0)
+      activesupport
+      code_analyzer (>= 0.4.3)
+      erubis
+      i18n
+      json
+      require_all
+      ruby-progressbar
     rails_serve_static_assets (0.0.1)
     rails_stdout_logging (0.0.3)
     railties (4.1.6)
@@ -175,6 +201,7 @@ GEM
       activesupport (= 4.1.6)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.2.1)
     raindrops (0.13.0)
     rake (10.3.2)
     rb-fsevent (0.9.4)
@@ -200,6 +227,11 @@ GEM
     redis-store (1.1.4)
       redis (>= 2.2)
     request_store (1.1.0)
+    require_all (1.4.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -220,12 +252,21 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     sass (3.2.19)
     sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
+    scrivener (1.0.0)
+    sexp_processor (4.8.0)
     slop (3.6.0)
     sprockets (2.11.0)
       hike (~> 1.2)
@@ -248,6 +289,10 @@ GEM
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+    unicode-display_width (1.1.3)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -262,6 +307,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap-sass
+  byebug
   cancan
   capybara
   coffee-rails (~> 4.0.0)
@@ -271,9 +317,11 @@ DEPENDENCIES
   guard-rspec
   haml-rails
   jquery-rails
+  mailgun-ruby (~> 1.0.2)
   newrelic_rpm
   ohm
   ohm-contrib
+  ohm-validations
   omniauth
   omniauth-github
   poltergeist
@@ -283,12 +331,17 @@ DEPENDENCIES
   rack-ssl
   rails (= 4.1.6)
   rails_12factor
+  rails_best_practices
   redis-rails
   rspec-rails
+  rubocop
   sass-rails (~> 4.0.3)
   turbolinks
   uglifier (>= 1.3.0)
   unicorn
 
+RUBY VERSION
+   ruby 2.2.2p95
+
 BUNDLED WITH
-   1.10.6
+   1.14.4

--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@ Github has a nice link. Right there, on the right of your page!
 
 #### Dependencies
 
-Install Ruby 2.1.2 if necessary (if you use `rbenv`, it will yell at you if you
+Install Ruby 2.2.2 if necessary (if you use `rbenv`, it will yell at you if you
 don't).
+
+Using `rbenv` gemsets:
+    $ cd movierama
+    $ rbenv gemset create 2.2.2 movierama
+    $ echo -n "movierama" > .rbenv-gemsets
 
 Run `bundler` as usual:
 
@@ -37,16 +42,16 @@ Check that everything works by seeding the database with a few users and movies:
 As the application requires HTTPS, you will need a local setup that supports
 that.
 
-Follow [these instructions](http://dec0de.me/2014/10/pow-ssl/) if you usually
-use Pow; otherwise:
-
 Install `tunnelss`:
 
     $ gem install tunnelss
+    $ mkdir -p $HOME/.pow
+    $ ln -s $HOME/<path...>/movierama $HOME/.pow/movierama
+    $ rbenv rehash
 
 Run the SSL tunnel in a terminal:
 
-    $ tunnelss 24676 24675
+    $ sudo tunnelss 443 24675
 
 Run the application on the corresponding port:
 
@@ -65,6 +70,10 @@ Login/signup use Omniauth with Github as a provider. If you're using Pow and the
 If not, you'll need to get your own OAuth tokens from Github and edit
 `.env` appropriately.
 
+
+#### Running the test suite
+
+    $ rspec
 
 
 ### Screenshot

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   def index
-    # TODO: extract loginc into a Search service
+    # TODO: extract logic into a Search service
     if _index_params[:user_id]
       @submitter = User[_index_params[:user_id]]
       scope = Movie.find(user_id: @submitter.id)

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -3,6 +3,12 @@ class VotesController < ApplicationController
     authorize! :vote, _movie
 
     _voter.vote(_type)
+
+    # TODO: should Email be some kind of persistent service?
+    # send the movie-creator an email about the vote
+    Email.new.send_email(_movie_creator, 'vote_received',
+                         'movie': _movie)
+
     redirect_to root_path, notice: 'Vote cast'
   end
 
@@ -29,5 +35,9 @@ class VotesController < ApplicationController
 
   def _movie
     @_movie ||= Movie[params[:movie_id]]
+  end
+
+  def _movie_creator
+    @_movie_creator = _movie.user
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < BaseModel
   include Ohm::Timestamps
+  include Ohm::Validations
 
   attribute :name
 
@@ -14,4 +15,18 @@ class User < BaseModel
 
   # Submitted movies
   collection :movies, :Movie
+
+  # Email address, from Github.
+  # Since omniauth-1.2, this has been verified by github. However, our copy may
+  #   have gone stale since the users last login.
+  # https://github.com/intridea/omniauth-github/issues/36
+  attribute :email
+
+  attribute :updated_at # TODO: why isn't this needed for :created_at?
+
+  # TODO: fix this
+  # protected
+  # def validate
+  #  assert_email(:email)
+  # end
 end

--- a/app/services/email.rb
+++ b/app/services/email.rb
@@ -1,0 +1,54 @@
+
+require 'email_services'
+
+# Organises and sends email, selecting a provider based on config
+class Email
+  def send_email(user, email_type, *_args)
+    # TODO: this would be way better if this injected movie info into the email
+    # TODO: move this into a map of type => details
+    if email_type == 'vote_received'
+      @subject = 'One of your movies got clicked!'
+      @text = 'It sure did!'
+      @from = 'info@movierama.com'
+    else
+      logger.error 'Unknown email type: #{email_type}'
+      return
+    end
+
+    # TODO: rate-limit sending to a particular address
+    @to = user.email
+
+    if @to.nil?
+      # the user who created the movie has no email address on file
+      Rails.logger.info 'No email address for ' + user.uid
+      return
+    end
+
+    # TODO: Don't try/catch on critical emails -- eg. security-related
+    # TODO: do this async (requires activejob / rails 4.2)
+    # TODO: should not send immediately - give grace period for active
+    #   user to undo
+    begin
+      _mailer.send_email(@from, @to, @subject, @text)
+    rescue StandardError
+      Rails.logger.error 'Failed to send ' + email_type + ' to ' + user.uid
+      # TODO: log enough to debug
+    end
+  end
+
+  # TODO: Don't pick a mailer from an available set & send the thing -
+  #   instead, DI in a mailer at the config stage
+  def _mailer
+    provider = Rails.configuration.email_provider
+
+    # TODO: it would be nice to be able to switch these dynamically
+    if provider == 'log_only'
+      @mailer = LogOnlyEmail.new
+    elsif provider == 'mailgun'
+      @mailer = MailgunEmail
+    else
+      Rails.logger.debug 'No email provider configured. Got: ' + provider
+      # TODO: a stat & an alert if this is seen in prod
+    end
+  end
+end

--- a/app/services/email_services.rb
+++ b/app/services/email_services.rb
@@ -1,0 +1,35 @@
+
+
+# For test/debug/early staging, implements the mailer interface, but does not
+# send email
+class LogOnlyEmail
+  def send_email(_from, to, subject, _text)
+    # TODO: increment a stat here & add an alert if the stat is seen
+    #   in production
+    Rails.logger.debug 'NullSending an email to ' + to +
+                       ' with subject: ' + subject
+  end
+end
+
+# Email-sending via Mailgun, an email-sending company.
+#
+# This class is not intended to be used directly, use higher-level
+#   `Email` instead.
+class MailgunEmail < ActionMailer::Base
+  def send_email(_from, to, subject, text)
+    Rails.logger.debug 'Sending mail via Mailgun'
+
+    @domain = Rails.configuration.email_mailgun_domain
+    @api_key = Rails.configuration.email_mailgun_api_key
+
+    message_params = {
+      from: 'jamesbroadhead@gmail.com', # from,
+      to: to,
+      subject: subject,
+      text: text
+    }
+
+    mg_client = Mailgun::Client.new @api_key
+    mg_client.send_message @domain, message_params
+  end
+end

--- a/app/services/user_registration.rb
+++ b/app/services/user_registration.rb
@@ -21,20 +21,28 @@ class UserRegistration
   private
 
   def _run
-    @ran and return
-    uid = "%s|%s" % [
+    @ran && return
+    uid = '%s|%s' % [
       @auth_hash['provider'],
       @auth_hash['uid']
     ]
 
     if user = User.find(uid: uid).first
+      # fill in emails from users who don't have them, or update the address on
+      #   file, in case it's changed github-side
+      user.email = @auth_hash['info']['email'],
+                   user.updated_at = Time.current.utc.to_i
       @user    = user
       @created = false
+
+      user.save # TODO: latency impact?
     else
       @user = User.create(
-        uid:        uid, 
+        uid:        uid,
         name:       @auth_hash['info']['name'],
-        created_at: Time.current.utc.to_i
+        email:      @auth_hash['info']['email'],
+        created_at: Time.current.utc.to_i,
+        updated_at: Time.current.utc.to_i
       )
       @created = true
     end

--- a/app/services/voting_booth.rb
+++ b/app/services/voting_booth.rb
@@ -16,7 +16,7 @@ class VotingBooth
     _update_counts
     self
   end
-  
+
   def unvote
     @movie.likers.delete(@user)
     @movie.haters.delete(@user)

--- a/app/views/movies/index.haml
+++ b/app/views/movies/index.haml
@@ -52,11 +52,11 @@
             - if current_user && can?(:vote, movie)
               .mr-movie-voting.pull-right
                 - if current_user.likes?(movie)
-                  You like this movie 
+                  You like this movie
                   = link_to movie_vote_path(movie), method: :delete do
                     Unlike
                 - elsif current_user.hates?(movie)
-                  You hate this movie 
+                  You hate this movie
                   = link_to movie_vote_path(movie), method: :delete do
                     Unhate
                 - else

--- a/app/views/movies/new.haml
+++ b/app/views/movies/new.haml
@@ -19,5 +19,5 @@
           %input.form-control{ name: 'date', type: 'date', value: @movie.date }
         .form-group
           = submit_tag 'Add movie', class: 'btn btn-primary'
-       
+
 

--- a/bin/dolint
+++ b/bin/dolint
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+FILES=("app/controllers/votes_controller.rb" "spec/controllers/movies_controller_spec.rb" "spec/controllers/votes_controller_spec.rb")
+
+rubocop -a -R -n "${FILES[@]}"
+
+rails_best_practices "${FILES[@]}"

--- a/bin/dolint
+++ b/bin/dolint
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FILES=("app/controllers/votes_controller.rb" "spec/controllers/movies_controller_spec.rb" "spec/controllers/votes_controller_spec.rb")
+FILES=("app/controllers/votes_controller.rb" "app/models/user.rb" "app/services/email.rb" "app/services/email_services.rb" "app/services/user_registration.rb" "spec/controllers/movies_controller_spec.rb" "spec/controllers/votes_controller_spec.rb")
 
 rubocop -a -R -n "${FILES[@]}"
 

--- a/bin/dotest
+++ b/bin/dotest
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+bundle exec rspec

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./bin/rails server -p 24675

--- a/bin/tunnel
+++ b/bin/tunnel
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo $(which tunnelss) 443 24675

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,4 +33,23 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   OmniAuth.config.full_host = "https://movierama.dev"
+
+  # Select an email provider from ['log_only', 'mailgun']
+  # TODO: config validation
+  config.email_provider = 'mailgun'
+
+  config.email_mailgun_api_key = 'key-c37046d1e571eb78c835613c272ee543'
+  config.email_mailgun_domain = 'sandbox3ceb4f2a8a3c4f189c9d38cec78a16ca.mailgun.org'
+
+	config.action_mailer.delivery_method = :smtp
+	# SMTP settings for mailgun
+	ActionMailer::Base.smtp_settings = {
+		:port           => 587,
+		:address        => "smtp.mailgun.org",
+		:domain         => 'sandbox3ceb4f2a8a3c4f189c9d38cec78a16ca.mailgun.org',
+		:user_name      => 'postmaster@sandbox3ceb4f2a8a3c4f189c9d38cec78a16ca.mailgun.org',
+
+		:password       => '24c80f55a887e54d9fd3d8d1b7524ca4',
+		:authentication => :plain,
+	}
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,4 +31,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  OmniAuth.config.full_host = "https://movierama.dev"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,4 +72,6 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  OmniAuth.config.full_host = "https://movierama.dev"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,4 +74,20 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   OmniAuth.config.full_host = "https://movierama.dev"
+
+  # Select an email provider from ['log_only', 'mailgun']
+  # TODO: config validation
+  config.email.provider = 'mailgun'
+
+  config.action_mailer.delivery_method = :smtp
+	# SMTP settings for mailgun
+	ActionMailer::Base.smtp_settings = {
+		:port           => 587,
+		:address        => "smtp.mailgun.org",
+		:domain         => 'sandbox3ceb4f2a8a3c4f189c9d38cec78a16ca.mailgun.org',
+		:user_name      => 'postmaster@sandbox3ceb4f2a8a3c4f189c9d38cec78a16ca.mailgun.org',
+
+		:password       => '24c80f55a887e54d9fd3d8d1b7524ca4',
+		:authentication => :plain,
+	}
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,4 +38,8 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   OmniAuth.config.full_host = "https://movierama.dev"
+
+  # Select an email provider from ['log_only', 'mailgun']
+  # TODO: config validation
+  config.email.provider = 'log_only'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,4 +36,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  OmniAuth.config.full_host = "https://movierama.dev"
 end

--- a/spec/acceptance/create_movie_spec.rb
+++ b/spec/acceptance/create_movie_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe 'submit movie', type: :feature do
 
   let(:page) { Pages::MovieNew.new }
 
-  context 'when logged out' do
-    it 'fails'
-  end
-
   context 'when logged in' do
     with_logged_in_user
     before { page.open }
@@ -22,8 +18,6 @@ RSpec.describe 'submit movie', type: :feature do
         date:        '1957-10-02')
       expect(page).to have_movie_creation_message
     end
-
-    it 'makes the movie visible on the home page'
 
     it 'fails without a date' do
       page.submit(

--- a/spec/controllers/movies_controller_spec.rb
+++ b/spec/controllers/movies_controller_spec.rb
@@ -1,26 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe MoviesController, :type => :controller do
-
-  describe "GET index" do
-    xit "returns http success" do
+RSpec.describe MoviesController, type: :controller do
+  describe 'GET index' do
+    xit 'returns http success' do
       get :index
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET new" do
-    xit "returns http success" do
+  describe 'GET new' do
+    xit 'returns http success' do
       get :new
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "POST create" do
-    xit "returns http success" do
+  describe 'POST create' do
+    xit 'returns http success' do
       post :create
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/controllers/movies_controller_spec.rb
+++ b/spec/controllers/movies_controller_spec.rb
@@ -1,24 +1,45 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe MoviesController, type: :controller do
+  before :each do
+    @ability = Object.new
+    @ability.extend(CanCan::Ability)
+    allow(controller).to receive(:current_ability) { @ability }
+  end
+
   describe 'GET index' do
-    xit 'returns http success' do
+    it 'succeed, logged out' do
       get :index
       expect(response).to have_http_status(:success)
     end
   end
 
   describe 'GET new' do
-    xit 'returns http success' do
-      get :new
-      expect(response).to have_http_status(:success)
+    it 'denies, without access' do
+      assert_raises CanCan::AccessDenied do
+        get :new
+      end
+    end
+
+    # TODO: is this the correct template to render?
+    it 'succeeds, with access' do
+      @ability.can :create, Movie
+      get :index
+      assert_template :index
     end
   end
 
   describe 'POST create' do
-    xit 'returns http success' do
+    it 'denies, without access' do
+      assert_raises CanCan::AccessDenied do
+        post :create
+      end
+    end
+
+    it 'succeeds, with access' do
+      @ability.can :create, Movie
       post :create
-      expect(response).to have_http_status(:success)
+      assert_template('movies/new')
     end
   end
 end

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -1,19 +1,17 @@
 require 'rails_helper'
 
-RSpec.describe VotesController, :type => :controller do
-
-  describe "GET create" do
-    xit "returns http success" do
+RSpec.describe VotesController, type: :controller do
+  describe 'GET create' do
+    xit 'returns http success' do
       get :create
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET destroy" do
-    xit "returns http success" do
+  describe 'GET destroy' do
+    xit 'returns http success' do
       get :destroy
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -1,16 +1,43 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe VotesController, type: :controller do
+  before :each do
+    @ability = Object.new
+    @ability.extend(CanCan::Ability)
+    allow(controller).to receive(:current_ability) { @ability }
+
+    allow(controller).to receive(:current_user) {
+      User.create(uid: 'null|12345', name: 'Alice')
+    }
+
+    # TODO: mock the movie too?
+    # TODO debug & step through :/
+  end
+
   describe 'GET create' do
-    xit 'returns http success' do
-      get :create
+    it 'denies, without access' do
+      assert_raises CanCan::AccessDenied do
+        get :create, params: { movie_id: 0, t: 'like' }
+      end
+    end
+
+    it 'succeeds, with access' do
+      @ability.can :vote, Movie
+      get :create, params: { movie_id: 0 }
       expect(response).to have_http_status(:success)
     end
   end
 
   describe 'GET destroy' do
-    xit 'returns http success' do
-      get :destroy
+    it 'denies, without access' do
+      assert_raises CanCan::AccessDenied do
+        get :destroy, params: { movie_id: 0 }
+      end
+    end
+
+    xit 'succeeds, with access' do
+      @ability.can :vote, Movie
+      get :create, params: { movie_id: 0 }
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/views/movies/create.haml_spec.rb
+++ b/spec/views/movies/create.haml_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "movies/create.html.erb", :type => :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/views/movies/index.haml_spec.rb
+++ b/spec/views/movies/index.haml_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "movies/index.html.erb", :type => :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/views/movies/show.haml_spec.rb
+++ b/spec/views/movies/show.haml_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "movies/show.html.erb", :type => :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/views/movies/update.haml_spec.rb
+++ b/spec/views/movies/update.haml_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "movies/update.html.erb", :type => :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
- When a movie receives a vote, send a basic email to the user who created the movie entry.
- 2 x email services, one uses Mailgun for email sending, the other is a logger for debug purposes
- Persists email addresses when users login via github. Caveat: these have been verified by github in the past, but may go stale. Add an 'updated_at' field to User to track the age of this field.
    
Review notes:
- This is my first patch in ruby - I have left many TODOs as points for extra attention. The work is functional, but incomplete.
- Mocking user auth in the vote controller is (still) broken
- Email sending itself needs stubbing & testing.
- Email address validation logic is disabled pending testing
