### PR TITLE
Feature: Notify author on vote

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+ROOT_URL:       https://movierama.dev
 DB_URL:			redis://127.0.0.1:6379/12
 CACHE_URL:		redis://127.0.0.1:6379/13
 PORT:			24675

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+# editors
+.vscode
+.idea
+
+# local redis
+dump.rdb

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem 'omniauth' # Authentication
 gem 'omniauth-github'
 gem 'cancan'   # Authorisation
 
+# Use wisper for event handling
+gem 'wisper'
+gem 'wisper-celluloid' # support async: true
 
 # Debugger
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,10 @@ GEM
       rack
       raindrops (~> 0.7)
     websocket-driver (0.3.5)
+    wisper (1.6.1)
+    wisper-celluloid (0.0.1)
+      celluloid
+      wisper
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.4)
@@ -289,6 +293,11 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   unicorn
+  wisper
+  wisper-celluloid
+
+RUBY VERSION
+   ruby 2.2.2p95
 
 BUNDLED WITH
-   1.10.6
+   1.14.4

--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ Login/signup use Omniauth with Github as a provider. If you're using Pow and the
 If not, you'll need to get your own OAuth tokens from Github and edit
 `.env` appropriately.
 
+#### Test emails locally
 
+In order to test email sending locally please use [MailCatcher](https://mailcatcher.me/).
+
+Development environment is configured to send emails to `smtp://127.0.0.1:1025`.
 
 ### Screenshot
 

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -16,7 +16,12 @@ class VotesController < ApplicationController
   private
 
   def _voter
-    VotingBooth.new(current_user, _movie)
+    voter = VotingBooth.new(current_user, _movie)
+    
+    # register event subscribers
+    voter.subscribe(AuthorNotifier.new, async: true)
+
+    voter
   end
 
   def _type

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,14 @@
+class UserMailer < ActionMailer::Base
+
+  def movie_vote_cast(movie, voter, kind)
+    return unless movie.user.email
+
+    @voter = voter
+    @movie = movie
+    @user = movie.user
+    @kind = kind
+
+    mail(to: movie.user.email, subject: 'Someone voted on your movie!')
+  end
+  
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,10 @@ class User < BaseModel
 
   attribute :name
 
+  attribute :email
+  unique    :email
+  index     :email
+
   # Unique identifier for this user, in the form "{provider}|{provider-id}"
   attribute :uid
   index     :uid

--- a/app/services/author_notifier.rb
+++ b/app/services/author_notifier.rb
@@ -1,0 +1,10 @@
+class AuthorNotifier
+  def movie_vote_cast(movie_id, voter_id, kind)
+    # if moving to a queue model for sending emails
+    # we simply need to change the implementation of this method
+    # to put a message on a queue 
+    # that a queue worker (independelty scaled) will pick up and process
+    # .
+    UserMailer.movie_vote_cast(Movie[movie_id], User[voter_id], kind).deliver
+  end
+end

--- a/app/services/user_registration.rb
+++ b/app/services/user_registration.rb
@@ -34,6 +34,7 @@ class UserRegistration
       @user = User.create(
         uid:        uid, 
         name:       @auth_hash['info']['name'],
+        email:      @auth_hash['info']['email'],
         created_at: Time.current.utc.to_i
       )
       @created = true

--- a/app/services/voting_booth.rb
+++ b/app/services/voting_booth.rb
@@ -1,12 +1,14 @@
 # Cast or withdraw a vote on a movie
 class VotingBooth
+  include Wisper::Publisher
+
   def initialize(user, movie)
     @user  = user
     @movie = movie
   end
 
-  def vote(like_or_hate)
-    set = case like_or_hate
+  def vote(kind)
+    set = case kind
       when :like then @movie.likers
       when :hate then @movie.haters
       else raise
@@ -14,6 +16,9 @@ class VotingBooth
     unvote # to guarantee consistency
     set.add(@user)
     _update_counts
+
+    broadcast(:movie_vote_cast, @movie.id, @user.id, kind)
+
     self
   end
   

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -17,10 +17,10 @@
           %a.navbar-brand{ href: root_path } MovieRama
         - if current_user
           %p.navbar-text.navbar-right
-            Welcome back,
-            %span#username= current_user.name
+            Welcome back!
+            %span#username= "| #{current_user.name} (#{current_user.email})"
             = link_to session_path, method: :delete do
-              Log out
+              | Log out
         - else
           %a.navbar-right.btn.navbar-btn{ href: '/auth/github' }
             Log in

--- a/app/views/user_mailer/movie_vote_cast.html.erb
+++ b/app/views/user_mailer/movie_vote_cast.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Dear <%= @user.name %>!</p>
+    <p>
+      '<%= @voter.name %>' recently 
+      <%= @kind %>d your movie titled 
+      <b>'<%= @movie.title %>'</b>.
+    </p>
+    <p>Thanks! MovieRama team!</p>
+  </body>
+</html>

--- a/app/views/user_mailer/movie_vote_cast.text.erb
+++ b/app/views/user_mailer/movie_vote_cast.text.erb
@@ -1,0 +1,5 @@
+Dear <%= @user.name %>!
+
+'<%= @voter.name %>' recently <%= @kind %>d your movie titled '<%= @movie.title %>'.
+
+Thanks! MovieRama team!

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,8 @@ require "action_view/railtie"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
+require 'wisper'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,6 +15,14 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_options = { 
+    :from => 'noreply@movierama.dev' 
+  }
+  config.action_mailer.smtp_settings = { 
+    :address => "localhost", 
+    :port => 1025 
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,19 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_options = { 
+    :from => 'noreply@movierama.io' 
+  }
+  config.action_mailer.smtp_settings = {
+    :address              => "smtp.postmarkapp.com",
+    :port                 => 25,
+    :domain               => 'movierama.io',
+    :user_name            => ENV[POSTMARK_API_KEY],
+    :password             => ENV[POSTMARK_API_KEY],
+    :authentication       => 'plain',
+    :enable_starttls_auto => true  
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,6 +30,9 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_options = { 
+    :from => 'noreply@movierama.dev' 
+  }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,9 +1,10 @@
 require 'omniauth'
 
+OmniAuth.config.full_host = ENV['ROOT_URL'] unless Rails.env.test?
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer unless Rails.env.production?
   provider :github,
     ENV.fetch('GITHUB_OAUTH_CLIENT_ID'),
     ENV.fetch('GITHUB_OAUTH_SECRET')
 end
-

--- a/db/users.yml
+++ b/db/users.yml
@@ -1,9 +1,12 @@
 - name: John McFoo
   uid:  'null|johnmcfoo'
+  email: 'john@movierama.dev'
 - name: Alice Wallace
   uid:  'null|alice'
+  email: 'alice@movierama.dev'
 - name: Bob Ablleton
   uid:  'null|bob'
+  email: 'bob@movierama.dev'
 - name: Charlie O'Callaghan
   uid:  'null|charlie'
-
+  email: 'charlie@movierama.dev'

--- a/spec/acceptance/login_spec.rb
+++ b/spec/acceptance/login_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe 'login/logout/signup', type: :feature do
     expect(page).to have_signup_message
   end
 
+  it 'creates new user when sign up' do
+    page.sign_up
+
+    user = User.find(email: 'joe@movierama.dev')
+    expect(user).to_not be_nil
+  end
+
   it 'logs out' do
     page.sign_up
     page.logout

--- a/spec/acceptance/voting_spec.rb
+++ b/spec/acceptance/voting_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe 'vote on movies', type: :feature do
   before do
     author = User.create(
       uid:  'null|12345',
-      name: 'Bob'
+      name: 'Bob',
+      email: 'bob@movierama.dev'
     )
     Movie.create(
       title:        'Empire strikes back',
@@ -72,6 +73,18 @@ RSpec.describe 'vote on movies', type: :feature do
       expect {
         page.like('The Party')
       }.to raise_error(Capybara::ElementNotFound)
+    end
+
+    it 'notifies the owner when like' do 
+      expect {
+        page.like('Empire strikes back')
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+
+    it 'notifies the owner when hate' do 
+      expect {
+        page.hate('Empire strikes back')
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
   end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe UserMailer, :type => :mailer do
+
+    describe 'movie vote cast' do 
+        let(:kind) { :like }
+        let(:movie) { Movie.create(user: author, title: 'Empire strikes back') }
+        let(:voter) { User.create(name: 'Andy') }
+        let(:mail) { described_class.movie_vote_cast(movie, voter, kind).deliver }
+
+        context 'when author doesnt have email' do 
+            let(:author) { User.create(name: 'Bob') }
+            
+            it 'mail is not sent' do
+                expect(mail).to be_nil
+            end
+        end
+
+        context 'when author does have email' do 
+            let(:author) { User.create(name: 'Bob', email: 'bob@movierama.dev') }
+
+            context 'mail is sent' do
+                it { expect(mail).to_not be_nil }
+
+                it 'to the right person' do
+                    expect(mail.to).to eq(['bob@movierama.dev']) 
+                end
+
+                it 'with the right subject' do
+                    expect(mail.subject).to eq('Someone voted on your movie!')
+                end
+            end
+
+            context 'when it is a like' do
+                it 'body says movie is liked' do
+                    expect(mail.body.encoded).to include('recently liked your movie')
+                end
+            end
+
+            context 'when it is a hate' do
+                let(:kind) { :hate }
+                
+                it 'body says movie is hated' do
+                    expect(mail.body.encoded).to include('recently hated your movie')
+                end
+            end
+        end
+    end
+
+end

--- a/spec/support/with_user.rb
+++ b/spec/support/with_user.rb
@@ -8,7 +8,8 @@ module RspecSupportWithUser
         :github,
         uid: '12345',
         info: {
-          name: 'John McFoo'
+          name: 'John McFoo',
+          email: 'john@movierama.dev'
         }
       )
     end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,5 @@
+class UserMailerPreview < ActionMailer::Preview
+  def movie_vote_cast
+    UserMailer.movie_vote_cast(Movie.all.first, User.all.first, :like)
+  end
+end


### PR DESCRIPTION
> Author is sent an email notification every time someone likes/hates one of their movies.

#### Notes

- [wisper](https://github.com/krisleech/wisper) is used to add the logic via a pub/sub mechanism to avoid direct spaghetti code dependency.
- [wisper-celluloid](https://github.com/krisleech/wisper-celluloid) is used to handle email sending asynchronously to avoid affecting the user experience for an "under-the-hood" operation.
- [MailCatcher](https://mailcatcher.me/) is used for local testing.
- Omniauth config is changed slightly to deal with a bug stopping local testing with GitHub. [see this](http://awesomeprogrammer.com/blog/2012/12/09/dealing-with-omniauth-redirect-uri-mismatch-invalid-port-number-gotcha/).

#### Future work

- It makes sense to allow user to select whether or not they would like to receive an email. (Or even if they want to receive it immediately/daily).
- If this application were to deal with very large load of user visits, it maybe best to split the mail sending part into it's own sub-system (a tiny AWS lambda or Azure Functions piece) so that the "application" server would become lighter (only dealing with end-user requests) and wouldn't have to scale unnecessarily. -- In this instance a pub/sub queue maybe used as explained in a comment in `author_notifier.rb`.